### PR TITLE
201216_distinguish-email-and-username

### DIFF
--- a/src/Model/User/User.php
+++ b/src/Model/User/User.php
@@ -20,6 +20,10 @@ class User implements UserInterface
     /**
      * @var string|null
      */
+    private $username;
+    /**
+     * @var string|null
+     */
     private $plainPassword;
     /**
      * @var string|null
@@ -125,7 +129,7 @@ class User implements UserInterface
 
     public function getUsername(): string
     {
-        return $this->email;
+        return $this->username;
     }
 
     public function eraseCredentials(): void
@@ -174,19 +178,18 @@ class User implements UserInterface
         $this->additionalProperties = $additionalProperties;
     }
 
-    /**
-     * @return \DateTime
-     */
     public function getCreatedAt(): \DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param  \DateTime  $createdAt
-     */
     public function setCreatedAt(\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
+    }
+
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
     }
 }

--- a/src/Services/AutoMapper/UserConfig.php
+++ b/src/Services/AutoMapper/UserConfig.php
@@ -41,6 +41,12 @@ class UserConfig implements AutoMapperConfiguratorInterface
                 }
             )
             ->forMember(
+                'username',
+                function (UserJsonldUserRead $source) {
+                    return $source->getUsername();
+                }
+            )
+            ->forMember(
                 'userType',
                 function (UserJsonldUserRead $source) {
                     return $source->getUserType();
@@ -94,6 +100,12 @@ class UserConfig implements AutoMapperConfiguratorInterface
                 'email',
                 function (\VentureLeap\UserService\Model\User $source) {
                     return $source->getEmail();
+                }
+            )
+            ->forMember(
+                'username',
+                function (UserJsonldUserRead $source) {
+                    return $source->getUsername();
                 }
             )
             ->forMember(


### PR DESCRIPTION
So far, the email has been treated as the username. That is wrong.